### PR TITLE
TIKA-3360 Retrospective release of tika-helm for tika-docker 1.26 and 1.26-full

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -19,7 +19,7 @@
 ---
 apiVersion: v2
 name: tika
-version: "latest-full"
+version: "1.26-full"
 #kubeVersion:
 description: A Helm chart to deploy Apache Tika on Kubernetes
 type: application
@@ -34,10 +34,29 @@ sources:
   - https://github.com/apache/tika-helm
 #dependencies:
 maintainers:
-  - name: Lewis John McGibbney
-    email: lewismc@apache.org
-    url: https://github.com/lewismc
+  - name: Apache Tika Developers
+    email: dev@tika.apache.org
+    url: https://tika.apache.org
 icon: https://tika.apache.org/tika.png
-appVersion: "latest-full"
+appVersion: "1.26-full"
 deprecated: false
-#annotations:
+annotations:
+  # artifacthub.io/changes: |
+  #   - 
+  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/images: |
+    - name: tika
+      image: apache/tika:1.26-full
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Apache Tika
+      url: https://github.com/apache/tika
+    - name: Tika Helm Chart
+      url: https://github.com/apache/tika-helm
+    - name: Tika Docker Image
+      url: https://github.com/apache/tika-docker
+  artifacthub.io/maintainers: |
+    - name: Apache Tika Developers
+      email: dev@tika.apache.org
+  artifacthub.io/operator: "false"
+  artifacthub.io/prerelease: "false"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ tika-helm
 =========
 
 <!--[![Build Status](https://img.shields.io/jenkins/s/https/devops-ci.elastic.co/job/elastic+helm-charts+master.svg)](https://devops-ci.elastic.co/job/elastic+helm-charts+master/)-->
-[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/apache)](https://artifacthub.io/packages/search?repo=apache)
+<!--[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/apache)](https://artifacthub.io/packages/search?repo=apache)-->
 
 A [Helm chart][] to deploy [Apache Tika][] on [Kubernetes][].
 

--- a/values.yaml
+++ b/values.yaml
@@ -23,7 +23,7 @@ image:
   repository: apache/tika
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest-full"
+  tag: "1.26-full"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This ticket will act as the basis of the 1.26-full tika-helm release.