### PR TITLE
[TIKA-3381] Lock down the Tika environment in tika-helm

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -19,7 +19,7 @@
 ---
 apiVersion: v2
 name: tika
-version: "latest-full"
+version: "1.25"
 #kubeVersion:
 description: A Helm chart to deploy Apache Tika on Kubernetes
 type: application

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -19,7 +19,7 @@
 ---
 apiVersion: v2
 name: tika
-version: "1.25"
+version: "1.26"
 #kubeVersion:
 description: A Helm chart to deploy Apache Tika on Kubernetes
 type: application

--- a/values.yaml
+++ b/values.yaml
@@ -44,11 +44,11 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
   # runAsUser: 1000
 
 service:

--- a/values.yaml
+++ b/values.yaml
@@ -49,7 +49,8 @@ securityContext:
     - ALL
   readOnlyRootFilesystem: true
   runAsNonRoot: true
-  # runAsUser: 1000
+  runAsUser: 35002
+  runAsGroup: 35002
 
 service:
   type: ClusterIP

--- a/values.yaml
+++ b/values.yaml
@@ -43,7 +43,7 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
   capabilities:
     drop:
     - ALL


### PR DESCRIPTION
Dropping all kernel capabilities and not running as root user. This starts and seems to work loading the default page, but I would like to have a full test suite to make sure it doesn't break under the various parsing modes to be sure.