### PR TITLE
[TIKA-3483] Implement a network policy for Helm Chart

### DIFF
--- a/templates/networkpolicy.yaml
+++ b/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "tika-helm.fullname" . }}
+  labels:
+    {{- include "tika-helm.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "tika-helm.selectorLabels" . | nindent 6 }}
+  egress:
+    - {}
+  ingress:
+    - ports:
+      - port: {{ .Values.service.port }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+          matchLabels:
+            {{ template "tika-helm.fullname" . }}-client: "true"
+      {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -93,3 +93,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+networkPolicy:
+  # networkPolicy.enabled -- Create a network policy to restrict traffic to pods
+  # within the same namespace that include the label `<release>-client: true`.
+  enabled: false
+  # networkPolicy.allowExternal -- Don't require a "-client" label for connections.
+  allowExternal: false


### PR DESCRIPTION
This pull request proposes to create a network policy to restrict traffic to the Tika pods within the same namespace that include the label `<release>-client: true` e.g. `tika-client: true`