### PR TITLE
Fix invalid yaml document when helm lint is executed

### DIFF
--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 ---
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
### Error
Executing  `helm lint .` the following message is printed:
```
[ERROR] templates/serviceaccount.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: v1

Error: 1 chart(s) linted, 1 chart(s) failed
```

### Fix
Removing the dash in the file `templates/serviceaccount.yaml`, `helm lint .`  works.
See here: 
- https://github.com/helm/helm/issues/10149#issuecomment-929205040
- https://github.com/helm/helm/issues/10278#issuecomment-964445494


### Env
**helm version**: 
`version.BuildInfo{Version:"v3.11.0", GitCommit:"472c5736ab01133de504a826bd9ee12cbe4e7904", GitTreeState:"clean", GoVersion:"go1.19.5"}`
