### PR TITLE
feat(hpa): Allow setting apiVersion through values file

### DIFF
--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -17,7 +17,7 @@
 
 ---
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ .Values.autoscaling.apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tika-helm.fullname" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -82,6 +82,7 @@ resources:
     memory: 1500Mi
 
 autoscaling:
+  apiVersion: autoscaling/v2beta1
   enabled: false
   minReplicas: 1
   maxReplicas: 100


### PR DESCRIPTION
With K8s v1.25 being available, the HPA apiVersion has changed.
```
apiVersion: autoscaling/v2beta1
```
 is deprecated in favour of
```
apiVersion: autoscaling/v2
```
The change still uses the same default value for the apiVersion as before (since not everyone will have migrated to v1.25 yet) but it's now possible to change the value through the values-file