### PR TITLE
bugfix(deployment): Fix probe paths

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: {{if .Values.config.base_url }}{{- with urlParse (tpl .Values.config.base_url .) }}{{ .path }}{{end}}{{end}}/
+              path: {{if .Values.config.base_url }}{{- with urlParse (tpl .Values.config.base_url .) }}{{ .path }}{{end}}{{else}}/{{end}}
               port: {{ .Values.service.port }}
               scheme: {{ .Values.livenessProbe.scheme | default "http" }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 15 }}
@@ -72,7 +72,7 @@ spec:
             periodSeconds: {{ .Values.livenessProbe.periodSeconds | default 5 }}
           readinessProbe:
             httpGet:
-              path: {{if .Values.config.base_url }}{{- with urlParse (tpl .Values.config.base_url .) }}{{ .path }}{{end}}{{end}}/
+              path: {{if .Values.config.base_url }}{{- with urlParse (tpl .Values.config.base_url .) }}{{ .path }}{{end}}{{else}}/{{end}}
               port: {{ .Values.service.port  }}
               scheme: {{ .Values.readinessProbe.scheme | default "http" }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 15 }}

--- a/values.yaml
+++ b/values.yaml
@@ -118,4 +118,4 @@ networkPolicy:
   allowExternal: false
 
 config:
-  base_url: localhost
+  base_url: "http://localhost/"


### PR DESCRIPTION
@lewismc 

I did the following changes:
- Changed .Values.config.base_url: When it's not a proper URL, the urlParse function will give back wrong values for .path
- Removed the "/" at the end of the probe paths, since the path return by urlParse is correct on it's own
- Added an {{else}} clause in the probe path to catch the case when no base_url is provided.

For me, this setup seems to work.