### PR TITLE
bugfix(hpa): Fix hpa structure when the v2 apiVersion is set

### DIFF
--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -31,6 +31,24 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
+    {{- if eq .Values.autoscaling.apiVersion "autoscaling/v2" }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target: 
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target: 
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- else }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
@@ -42,5 +60,6 @@ spec:
       resource:
         name: cpu
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Fix hpa structure when the v2 apiVersion is set

@lewismc this fixes the layout of the hpa to the new apiversion when it's selected