### PR TITLE
Add support for service annotations

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -22,6 +22,10 @@ metadata:
   name: {{ include "tika-helm.fullname" . }}
   labels:
     {{- include "tika-helm.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.service.annotations }}
+      {{- toYaml . | nindent 4 }}
+      {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
This update allows users to specify custom annotations using the Helm values file. This is useful for configuring cloud-specific features like internal load balancers on AWS.

Example command to adjust annotations with this change:
```shell
helm upgrade tika ./tika-2.9.0.tgz --install -n tika \
  --set image.tag=2.9.0.0 \
  --set service.type=LoadBalancer \
  --set "service.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal=\"true\"" \
  --set "service.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-type=\"nlb\""
```

You can also adjust the `values.yaml` file manually instead of using `--set`.