### PR TITLE
TIKA-4271 Support tcpSocket probe

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -75,19 +75,29 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
+            {{- if eq (lower .Values.livenessProbe.scheme) "tcp" }}
+            tcpSocket:
+              port: {{ .Values.service.port }}
+            {{- else }}
             httpGet:
               path: {{if .Values.config.base_url }}{{- with urlParse (tpl .Values.config.base_url .) }}{{ .path }}{{end}}{{else}}/{{end}}
               port: {{ .Values.service.port }}
               scheme: {{ .Values.livenessProbe.scheme | default "http" }}
+            {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 15 }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default 30 }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold | default 20 }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds | default 5 }}
           readinessProbe:
+            {{- if eq (lower .Values.readinessProbe.scheme) "tcp" }}
+            tcpSocket:
+              port: {{ .Values.service.port }}
+            {{- else }}
             httpGet:
               path: {{if .Values.config.base_url }}{{- with urlParse (tpl .Values.config.base_url .) }}{{ .path }}{{end}}{{else}}/{{end}}
               port: {{ .Values.service.port  }}
               scheme: {{ .Values.readinessProbe.scheme | default "http" }}
+            {{- end }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 15 }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default 30 }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold | default 20 }}

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -60,3 +60,42 @@ tests:
               timeoutSeconds: 30
               failureThreshold: 20
               periodSeconds: 5
+  - it: should allow tcp probe
+    set:
+      image.tag: latest
+      readinessProbe.scheme: tcp
+      livenessProbe.scheme: tcp
+    asserts:
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - matchRegex:
+          path: metadata.name
+          pattern: RELEASE-NAME-tika
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: apache/tika:latest
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+      - isSubset:
+          path: spec.template.spec.containers[0]
+          content:
+            livenessProbe:
+              tcpSocket:
+                port: 9998
+              initialDelaySeconds: 15
+              timeoutSeconds: 30
+              failureThreshold: 20
+              periodSeconds: 5
+      - isSubset:
+          path: spec.template.spec.containers[0]
+          content:
+            readinessProbe:
+              tcpSocket:
+                port: 9998
+              initialDelaySeconds: 15
+              timeoutSeconds: 30
+              failureThreshold: 20
+              periodSeconds: 5


### PR DESCRIPTION
With the active gRPC Server development
(https://issues.apache.org/jira/browse/TIKA-4181), there is need to be able to deploy this Helm chart against the running gRPC service.

As the exposed gRPC service cannot use the HTTP probe, we must adapt the Helm chart to be configurable for a tcp socket

This change identifies `tcp` in the scheme variable of either probe and ensures the appropriate mechanism is used.

Existing HTTP(S) functionality continues to be supported.