### PR TITLE
Namespace & NetworkPolicy Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,130 @@
+# Created by https://www.toptal.com/developers/gitignore/api/macos,intellij+all,helm
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,intellij+all,helm
+
+### Helm ###
+# Chart dependencies
+**/charts/*.tgz
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,intellij+all,helm
 test-output.xml

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: tika
 appVersion: "3.0.0.0-full"
-version: "3.0.0-full"
+version: "3.0.1-full"
 description: The official Helm chart for Apache Tika
 type: application
 keywords:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,4 +1,16 @@
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "tika-helm.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "tika-helm.name" -}}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -21,6 +21,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Chart.Name }}-config
+  namespace: {{ include "tika-helm.namespace" . }}
 data:
   tika-config.xml: |-
 {{ .Values.tikaConfig | indent 4 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -20,6 +20,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "tika-helm.fullname" . }}
+  namespace: {{ include "tika-helm.namespace" . }}
   labels:
     {{- include "tika-helm.labels" . | nindent 4 }}
 spec:

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -21,6 +21,7 @@ apiVersion: {{ .Values.autoscaling.apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tika-helm.fullname" . }}
+  namespace: {{ include "tika-helm.namespace" . }}
   labels:
     {{- include "tika-helm.labels" . | nindent 4 }}
 spec:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -34,6 +34,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "tika-helm.namespace" . }}
   labels:
     {{- include "tika-helm.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/templates/networkpolicy.yaml
+++ b/templates/networkpolicy.yaml
@@ -36,7 +36,7 @@ spec:
       {{- if not .Values.networkPolicy.allowExternal }}
       from:
         - podSelector:
-          matchLabels:
-            {{ template "tika-helm.fullname" . }}-client: "true"
+            matchLabels:
+              {{ template "tika-helm.fullname" . }}-client: "true"
       {{- end }}
 {{- end }}

--- a/templates/networkpolicy.yaml
+++ b/templates/networkpolicy.yaml
@@ -21,6 +21,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "tika-helm.fullname" . }}
+  namespace: {{ include "tika-helm.namespace" . }}
   labels:
     {{- include "tika-helm.labels" . | nindent 4 }}
 spec:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -20,6 +20,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "tika-helm.fullname" . }}
+  namespace: {{ include "tika-helm.namespace" . }}
   labels:
     {{- include "tika-helm.labels" . | nindent 4 }}
   annotations:

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -21,6 +21,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "tika-helm.serviceAccountName" . }}
+  namespace: {{ include "tika-helm.namespace" . }}
   labels:
     {{- include "tika-helm.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/templates/tests/test-connection.yaml
+++ b/templates/tests/test-connection.yaml
@@ -20,6 +20,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "tika-helm.fullname" . }}-test-connection"
+  namespace: {{ include "tika-helm.namespace" . }}
   labels:
     {{- include "tika-helm.labels" . | nindent 4 }}
   annotations:

--- a/values.yaml
+++ b/values.yaml
@@ -28,6 +28,7 @@ image:
 imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: ''
+namespaceOverride: ''
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
This PR aims to fix two issues present in this helm chart:

- Network policy indent error
- Missing explicit namespace

---

The first issue is relatively straightforward to understand. Meanwhile, the rationale behind the second issue is that there are cases where it becomes quite complicated to deploy the application unless the namespace is explicitly provided — for example, when managing the application using a GitOps approach.