### PR TITLE
feat: allow env vars to be set

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: tika
 appVersion: "3.0.0.0-full"
-version: "3.0.1-full"
+version: "3.0.2-full"
 description: The official Helm chart for Apache Tika
 type: application
 keywords:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -60,6 +60,10 @@ spec:
           {{- if .Values.tikaConfig }}
           args: ["-c" , "/tika-config/tika-config.xml"]
           {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/values.yaml
+++ b/values.yaml
@@ -23,12 +23,19 @@ image:
   repository: apache/tika
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: '3.0.0.0-full'
+  tag: "3.0.0.0-full"
 
 imagePullSecrets: []
-nameOverride: ''
-fullnameOverride: ''
-namespaceOverride: ''
+nameOverride: ""
+fullnameOverride: ""
+namespaceOverride: ""
+
+# Environment variables to set in the container
+# For example:
+# env:
+#   - name: SOME_VAR
+#     value: "some value"
+# env: []
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -37,7 +44,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: ''
+  name: ""
 
 podAnnotations: {}
 
@@ -93,10 +100,10 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
-    cpu: '2'
+    cpu: "2"
     memory: 2000Mi
   requests:
-    cpu: '1'
+    cpu: "1"
     memory: 1500Mi
 
 autoscaling:
@@ -121,7 +128,7 @@ networkPolicy:
   allowExternal: false
 
 config:
-  base_url: 'http://localhost/'
+  base_url: "http://localhost/"
 # Use the below block to use custom tika-config.xml.
 # Refer https://tika.apache.org/2.9.1/configuring.html to know more about configuring apache-tika
 # tikaConfig: |


### PR DESCRIPTION
It would be useful to set environment variables to the container such as `JAVA_OPTS`.

This is before the changes:

```sh
» helm template . | grep container -A5
      containers:
        - name: tika
          securityContext:
            allowPrivilegeEscalation: true
            capabilities:
              drop:
```

This is after the changes, setting the `env`:

```sh
» helm template . | grep container -A5
      containers:
        - name: tika
          env:
            - name: SOME_VAR
              value: some value
          securityContext:
```