### PR TITLE
TIKA-4677 Migrate tika-helm Helm Chart tooling from belitre/helm-push-artifactory-plugin to jfrog cli

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
       - name: Set up chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
       - name: Run chart-testing (list-changed)

--- a/.github/workflows/pluto.yaml
+++ b/.github/workflows/pluto.yaml
@@ -26,7 +26,7 @@ jobs:
   pluto_detect:
     runs-on: ubuntu-latest
     env:
-      PLUTO_VERSION: 5.22.7
+      PLUTO_VERSION: 5.23.5
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -44,7 +44,7 @@ jobs:
           chmod +x /usr/local/bin/pluto
         shell: bash
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
       - name: verify helm chart
         run: |
           helm template . | pluto detect -omarkdown - >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,15 +14,18 @@
 # limitations under the License.
 
 # This workflow creates a GitHub Release and publishes the Helm chart to the
-# Apache JFrog Artifactory dedicated Helm OCI repository whenever a v* tag is pushed.
-# Chart is published via JFrog CLI and Helm OCI (helm package, helm registry login, helm push).
+# Apache JFrog Artifactory Helm OCI repository whenever a v* tag is pushed.
+#
+# Publishing uses JFrog CLI (`jf helm`) so the chart push is tied to Artifactory
+# build-info: CI environment and Git metadata are attached, then the build is
+# published for traceability (Builds UI, Xray, promotion flows, etc.).
 #
 # Required GitHub Secrets:
 #   ARTIFACTORY_USERNAME -- Apache JFrog Artifactory username
 #   ARTIFACTORY_PASSWORD -- Apache JFrog Artifactory password
 #
-# Prerequisite: A dedicated Helm OCI repository must exist in Artifactory (e.g. tika-helm-oci).
-# Confirm the repo key with Apache Infra and set HELM_OCI_REPO below if different.
+# Prerequisite: The Helm OCI repository must exist in Apache JFrog (Tika project), e.g. tika-helm.
+# Confirm the repo key and project with Apache Infra and set HELM_OCI_REPO / JF_PROJECT_KEY if different.
 
 name: Release Helm Chart
 
@@ -36,7 +39,10 @@ permissions:
 
 env:
   JF_URL: https://apache.jfrog.io
-  HELM_OCI_REPO: tika-helm-oci
+  HELM_OCI_REPO: tika-helm
+  JF_PROJECT_KEY: tika
+  JF_BUILD_NAME: tika-helm
+  JF_BUILD_NUMBER: ${{ github.run_id }}
 
 jobs:
   release:
@@ -44,6 +50,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Extract versions from Chart.yaml
         id: versions
@@ -65,7 +73,9 @@ jobs:
             **Chart version:** `${{ steps.versions.outputs.chart_version }}`
             **App version (Docker image tag):** `${{ steps.versions.outputs.app_version }}`
 
-            **Install from Helm OCI:** `helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version ${{ steps.versions.outputs.chart_version }}`
+            **Install from Helm OCI:** `helm install tika oci://apache.jfrog.io/artifactory/${{ env.HELM_OCI_REPO }}/tika --version ${{ steps.versions.outputs.chart_version }}`
+
+            **Artifactory build:** `${{ env.JF_BUILD_NAME }}` / `${{ env.JF_BUILD_NUMBER }}` (project `${{ env.JF_PROJECT_KEY }}`)
 
             [View available tags on Docker Hub](https://hub.docker.com/r/apache/tika/tags)
           generate_release_notes: true
@@ -87,15 +97,30 @@ jobs:
         run: helm package . --version ${{ steps.versions.outputs.chart_version }}
         shell: bash
 
-      - name: Log in to Helm OCI registry
+      - name: Log in to Helm OCI registry (JFrog CLI)
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-        run: |
-          echo "$ARTIFACTORY_PASSWORD" | helm registry login apache.jfrog.io --username "$ARTIFACTORY_USERNAME" --password-stdin
+        run: >-
+          jf helm registry login apache.jfrog.io
+          --username "$ARTIFACTORY_USERNAME"
+          --password "$ARTIFACTORY_PASSWORD"
         shell: bash
 
-      - name: Push Helm chart to Artifactory (Helm OCI)
+      - name: Push Helm chart (JFrog CLI, build-info)
+        env:
+          CHART_VERSION: ${{ steps.versions.outputs.chart_version }}
         run: |
-          helm push tika-${{ steps.versions.outputs.chart_version }}.tgz "oci://apache.jfrog.io/artifactory/${{ env.HELM_OCI_REPO }}"
+          jf helm push "tika-${CHART_VERSION}.tgz" \
+            "oci://apache.jfrog.io/artifactory/${HELM_OCI_REPO}" \
+            --build-name="${JF_BUILD_NAME}" \
+            --build-number="${JF_BUILD_NUMBER}" \
+            --project="${JF_PROJECT_KEY}"
+        shell: bash
+
+      - name: Enrich and publish build info
+        run: |
+          jf rt build-collect-env "${JF_BUILD_NAME}" "${JF_BUILD_NUMBER}"
+          jf rt build-add-git "${JF_BUILD_NAME}" "${JF_BUILD_NUMBER}"
+          jf rt build-publish --project="${JF_PROJECT_KEY}" "${JF_BUILD_NAME}" "${JF_BUILD_NUMBER}"
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,11 +14,15 @@
 # limitations under the License.
 
 # This workflow creates a GitHub Release and publishes the Helm chart to the
-# Apache JFrog Artifactory repository whenever a v* tag is pushed.
+# Apache JFrog Artifactory dedicated Helm OCI repository whenever a v* tag is pushed.
+# Chart is published via JFrog CLI and Helm OCI (helm package, helm registry login, helm push).
 #
 # Required GitHub Secrets:
 #   ARTIFACTORY_USERNAME -- Apache JFrog Artifactory username
 #   ARTIFACTORY_PASSWORD -- Apache JFrog Artifactory password
+#
+# Prerequisite: A dedicated Helm OCI repository must exist in Artifactory (e.g. tika-helm-oci).
+# Confirm the repo key with Apache Infra and set HELM_OCI_REPO below if different.
 
 name: Release Helm Chart
 
@@ -29,6 +33,10 @@ on:
 
 permissions:
   contents: write
+
+env:
+  JF_URL: https://apache.jfrog.io
+  HELM_OCI_REPO: tika-helm-oci
 
 jobs:
   release:
@@ -57,6 +65,8 @@ jobs:
             **Chart version:** `${{ steps.versions.outputs.chart_version }}`
             **App version (Docker image tag):** `${{ steps.versions.outputs.app_version }}`
 
+            **Install from Helm OCI:** `helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version ${{ steps.versions.outputs.chart_version }}`
+
             [View available tags on Docker Hub](https://hub.docker.com/r/apache/tika/tags)
           generate_release_notes: true
           draft: false
@@ -65,13 +75,27 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
 
-      - name: Install helm-push-artifactory-plugin
-        run: helm plugin install https://github.com/belitre/helm-push-artifactory-plugin --version 1.0.2
+      - name: Set up JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        with:
+          version: 2.92.0
+          jfrog-url: ${{ env.JF_URL }}
+          jfrog-username: ${{ secrets.ARTIFACTORY_USERNAME }}
+          jfrog-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+
+      - name: Package Helm chart
+        run: helm package . --version ${{ steps.versions.outputs.chart_version }}
         shell: bash
 
-      - name: Push Helm chart to Artifactory
+      - name: Log in to Helm OCI registry
         env:
-          HELM_REPO_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          HELM_REPO_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-        run: helm push-artifactory . https://apache.jfrog.io/artifactory/tika
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+        run: |
+          echo "$ARTIFACTORY_PASSWORD" | helm registry login apache.jfrog.io --username "$ARTIFACTORY_USERNAME" --password-stdin
+        shell: bash
+
+      - name: Push Helm chart to Artifactory (Helm OCI)
+        run: |
+          helm push tika-${{ steps.versions.outputs.chart_version }}.tgz "oci://apache.jfrog.io/artifactory/${{ env.HELM_OCI_REPO }}"
         shell: bash

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ in which case you may need to augment the commands below.
   - Example:
 ```
 helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version 3.2.3 --set image.tag=latest-full -n tika-test
+```
 
 ...
 NAME: tika

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ will work with the version of Tika you are installing.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Installing](#installing)
-  - [Install released version using Helm repository](#install-released-version-using-helm-repository)
+  - [Install released version from Helm OCI registry](#install-released-version-from-helm-oci-registry)
   - [Install development version using main branch](#install-development-version-using-main-branch)
   - [Custom configuration for tika](#custom-configuration-for-tika)
 - [Upgrading](#upgrading)
@@ -37,18 +37,21 @@ will work with the version of Tika you are installing.
 
 ## Installing
 
-### Install released version using Helm repository
+### Install released version from Helm OCI registry
+
+Charts are published to a dedicated Helm OCI repository on Apache JFrog Artifactory. Install directly from the OCI registry (Helm 3.8+).
 
 **N.B.** You may or may not need/wish to install the chart into a specific **namespace**,
 in which case you may need to augment the commands below.
 
-* Add the Tika Helm charts repo:
-`helm repo add tika https://apache.jfrog.io/artifactory/tika`
+* If the registry requires authentication (e.g. for private access), log in first:
+`helm registry login apache.jfrog.io --username <your-username> --password <your-password>`
 
-* Install it:
-  - with Helm 3: `helm install tika tika/tika --set image.tag=${release.version} -n tika-test`, you will see something like
+* Install from OCI (replace `<version>` with the chart version you want, e.g. `3.2.3`):
+  - with Helm 3: `helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version <version> --set image.tag=<app-version> -n tika-test`
+  - Example:
 ```
-helm install tika tika/tika --set image.tag=latest-full -n tika-test
+helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version 3.2.3 --set image.tag=latest-full -n tika-test
 
 ...
 NAME: tika
@@ -68,6 +71,8 @@ You may notice that the _kubectl port forwarding_ experiences a _timeout issue_ 
 while true; do kubectl --namespace tika-test port-forward $POD_NAME 9998:$CONTAINER_PORT ; done
 ```
 ... this should keep `kubectl` reconnecting on connection lost.
+
+**Note:** The classic Helm repository (`helm repo add tika https://apache.jfrog.io/artifactory/tika`) is deprecated and no longer receives new chart releases. Please use the Helm OCI install above.
 
 ### Install development version using main branch
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ will work with the version of Tika you are installing.
 
 ### Install released version from Helm OCI registry
 
-Charts are published to a dedicated Helm OCI repository on Apache JFrog Artifactory. Install directly from the OCI registry (Helm 3.8+).
+Charts are published to the [Tika Helm OCI repository](https://apache.jfrog.io/ui/repos/tree/General/tika-helm?projectKey=tika) on Apache JFrog Artifactory. Install directly from the OCI registry (Helm 3.8+).
 
 **N.B.** You may or may not need/wish to install the chart into a specific **namespace**,
 in which case you may need to augment the commands below.
@@ -48,10 +48,10 @@ in which case you may need to augment the commands below.
 `helm registry login apache.jfrog.io --username <your-username> --password <your-password>`
 
 * Install from OCI (replace `<version>` with the chart version you want, e.g. `3.2.3`):
-  - with Helm 3: `helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version <version> --set image.tag=<app-version> -n tika-test`
+  - with Helm 3: `helm install tika oci://apache.jfrog.io/artifactory/tika-helm/tika --version <version> --set image.tag=<app-version> -n tika-test`
   - Example:
 ```
-helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version 3.2.3 --set image.tag=latest-full -n tika-test
+helm install tika oci://apache.jfrog.io/artifactory/tika-helm/tika --version 3.2.3 --set image.tag=latest-full -n tika-test
 ```
 
 ...

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -39,7 +39,7 @@ will work with the version of Tika you are installing.
 
 ### Install released version from Helm OCI registry
 
-Charts are published to a dedicated Helm OCI repository on Apache JFrog Artifactory. Install directly from the OCI registry (Helm 3.8+).
+Charts are published to the [Tika Helm OCI repository](https://apache.jfrog.io/ui/repos/tree/General/tika-helm?projectKey=tika) on Apache JFrog Artifactory. Install directly from the OCI registry (Helm 3.8+).
 
 **N.B.** You may or may not need/wish to install the chart into a specific **namespace**, 
 in which case you may need to augment the commands below.
@@ -48,10 +48,10 @@ in which case you may need to augment the commands below.
 `helm registry login apache.jfrog.io --username <your-username> --password <your-password>`
 
 * Install from OCI (replace `<version>` with the chart version you want, e.g. `3.2.3`):
-  - with Helm 3: `helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version <version> --set image.tag=<app-version> -n tika-test`
+  - with Helm 3: `helm install tika oci://apache.jfrog.io/artifactory/tika-helm/tika --version <version> --set image.tag=<app-version> -n tika-test`
   - Example:
 ```
-helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version 3.2.3 --set image.tag=latest-full -n tika-test
+helm install tika oci://apache.jfrog.io/artifactory/tika-helm/tika --version 3.2.3 --set image.tag=latest-full -n tika-test
 ```
 
 ...

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -49,6 +49,10 @@ in which case you may need to augment the commands below.
 
 * Install from OCI (replace `<version>` with the chart version you want, e.g. `3.2.3`):
   - with Helm 3: `helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version <version> --set image.tag=<app-version> -n tika-test`
+  - Example:
+```
+helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version 3.2.3 --set image.tag=latest-full -n tika-test
+```
 
 ...
 NAME: tika

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -20,7 +20,7 @@ will work with the version of Tika you are installing.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Installing](#installing)
-  - [Install released version using Helm repository](#install-released-version-using-helm-repository)
+  - [Install released version from Helm OCI registry](#install-released-version-from-helm-oci-registry)
   - [Install development version using main branch](#install-development-version-using-main-branch)
   - [Custom configuration for tika](#custom-configuration-for-tika)
 - [Upgrading](#upgrading)
@@ -37,18 +37,18 @@ will work with the version of Tika you are installing.
 
 ## Installing
 
-### Install released version using Helm repository
+### Install released version from Helm OCI registry
+
+Charts are published to a dedicated Helm OCI repository on Apache JFrog Artifactory. Install directly from the OCI registry (Helm 3.8+).
 
 **N.B.** You may or may not need/wish to install the chart into a specific **namespace**, 
 in which case you may need to augment the commands below.
 
-* Add the Tika Helm charts repo:
-`helm repo add tika https://apache.jfrog.io/artifactory/tika`
+* If the registry requires authentication (e.g. for private access), log in first:
+`helm registry login apache.jfrog.io --username <your-username> --password <your-password>`
 
-* Install it:
-  - with Helm 3: `helm install tika tika/tika --set image.tag=${release.version} -n tika-test`, you will see something like
-```
-helm install tika tika/tika --set image.tag=latest-full -n tika-test
+* Install from OCI (replace `<version>` with the chart version you want, e.g. `3.2.3`):
+  - with Helm 3: `helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version <version> --set image.tag=<app-version> -n tika-test`
 
 ...
 NAME: tika
@@ -68,6 +68,8 @@ You may notice that the _kubectl port forwarding_ experiences a _timeout issue_ 
 while true; do kubectl --namespace tika-test port-forward $POD_NAME 9998:$CONTAINER_PORT ; done
 ```
 ... this should keep `kubectl` reconnecting on connection lost.
+
+**Note:** The classic Helm repository (`helm repo add tika https://apache.jfrog.io/artifactory/tika`) is deprecated and no longer receives new chart releases. Please use the Helm OCI install above.
 
 ### Install development version using main branch
 

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -17,6 +17,9 @@
 
 # Artifact Hub repository metadata file
 #
+# Charts are published to the Helm OCI registry: oci://apache.jfrog.io/artifactory/tika-helm-oci
+# Install: helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version <version>
+#
 # Some settings like the verified publisher flag or the ignored packages won't
 # be applied until the next time the repository is processed. Please keep in
 # mind that the repository won't be processed if it has not changed since the

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -17,8 +17,8 @@
 
 # Artifact Hub repository metadata file
 #
-# Charts are published to the Helm OCI registry: oci://apache.jfrog.io/artifactory/tika-helm-oci
-# Install: helm install tika oci://apache.jfrog.io/artifactory/tika-helm-oci/tika --version <version>
+# Charts are published to the Helm OCI registry: oci://apache.jfrog.io/artifactory/tika-helm
+# Install: helm install tika oci://apache.jfrog.io/artifactory/tika-helm/tika --version <version>
 #
 # Some settings like the verified publisher flag or the ignored packages won't
 # be applied until the next time the repository is processed. Please keep in


### PR DESCRIPTION
PR for [TIKA-4677](https://issues.apache.org/jira/browse/TIKA-4677)
I will contact Infra to request the creation of a Helm (OCI) entry for us to publish releases to. I'll update this thread once that is done.