### PR TITLE
TIKA-4678 Create GitHub Action automation to publish tika-helm to Artfactory on each merge to main branch

### DIFF
--- a/.github/workflows/install-test-chart.yaml
+++ b/.github/workflows/install-test-chart.yaml
@@ -55,7 +55,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
 
       - name: Create kind cluster
         uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0

--- a/.github/workflows/install-test-chart.yaml
+++ b/.github/workflows/install-test-chart.yaml
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reusable workflow: create a kind cluster, install the tika Helm chart
+# (from Artifactory by version or from repo at ref), then run helm test.
+#
+# Call with either:
+#   - chart_version: install from Artifactory (requires ARTIFACTORY_* secrets)
+#   - ref: install from repo at this ref (e.g. github.sha)
+
+name: Install and Test Chart
+
+on:
+  workflow_call:
+    inputs:
+      chart_version:
+        description: 'Chart version to install from Artifactory (e.g. 3.2.3-abc1234). Omit to install from repo.'
+        required: false
+        type: string
+      ref:
+        description: 'Git ref to checkout and install from (e.g. github.sha). Required when chart_version is not set.'
+        required: false
+        type: string
+    secrets:
+      ARTIFACTORY_USERNAME:
+        description: 'Apache JFrog Artifactory username (required when chart_version is set)'
+        required: false
+      ARTIFACTORY_PASSWORD:
+        description: 'Apache JFrog Artifactory password (required when chart_version is set)'
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  install-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        if: inputs.chart_version == ''
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Create kind cluster
+        uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
+
+      - name: Add Artifactory repo and pull chart
+        if: inputs.chart_version != ''
+        env:
+          HELM_REPO_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          HELM_REPO_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+        run: |
+          helm repo add tika https://apache.jfrog.io/artifactory/tika \
+            --username "$HELM_REPO_USERNAME" --password "$HELM_REPO_PASSWORD"
+          helm repo update
+          helm pull tika/tika --version ${{ inputs.chart_version }}
+
+      - name: Install chart from Artifactory
+        if: inputs.chart_version != ''
+        run: |
+          helm install tika tika-${{ inputs.chart_version }}.tgz \
+            -n tika-test --create-namespace \
+            --wait --timeout 5m
+
+      - name: Install chart from repo
+        if: inputs.chart_version == ''
+        run: |
+          helm install tika . \
+            -n tika-test --create-namespace \
+            --wait --timeout 5m
+
+      - name: Run helm test
+        run: helm test tika -n tika-test --timeout 3m

--- a/.github/workflows/install-test-chart.yaml
+++ b/.github/workflows/install-test-chart.yaml
@@ -87,3 +87,52 @@ jobs:
 
       - name: Run helm test
         run: helm test tika -n tika-test --timeout 3m
+
+      - name: Verify Tika HTTP root
+        run: |
+          sed 's/^          //' <<'JOB' | kubectl apply -f - -n tika-test
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: tika-http-root-check
+          spec:
+            backoffLimit: 2
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: curl
+                    image: curlimages/curl:latest
+                    command: ["sh", "-c"]
+                    args:
+                      - |
+                        code=$(curl -sf -o /dev/null -w "%{http_code}" http://tika:9998/)
+                        [ "$code" = "200" ] || { echo "Expected HTTP 200, got $code"; exit 1; }
+          JOB
+          kubectl wait --for=condition=complete job/tika-http-root-check -n tika-test --timeout=120s
+          kubectl delete job tika-http-root-check -n tika-test --ignore-not-found
+
+      - name: Verify Tika /tika endpoint
+        run: |
+          sed 's/^          //' <<'JOB' | kubectl apply -f - -n tika-test
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: tika-endpoint-check
+          spec:
+            backoffLimit: 2
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: curl
+                    image: curlimages/curl:latest
+                    command: ["sh", "-c"]
+                    args:
+                      - |
+                        # GET /tika returns 200 (OK) or 405 (Method Not Allowed) when endpoint is up
+                        code=$(curl -s -o /dev/null -w "%{http_code}" http://tika:9998/tika)
+                        case "$code" in 200|405) exit 0 ;; *) echo "Unexpected /tika status: $code"; exit 1 ;; esac
+          JOB
+          kubectl wait --for=condition=complete job/tika-endpoint-check -n tika-test --timeout=120s
+          kubectl delete job tika-endpoint-check -n tika-test --ignore-not-found

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -25,6 +25,8 @@ on:
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.list-changed.outputs.changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -45,9 +47,6 @@ jobs:
       - name: Run chart-testing (lint)
         run: ct lint --target-branch ${{ github.event.repository.default_branch }} --charts .
         shell: bash
-      - name: Create kind cluster
-        uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
-        if: steps.list-changed.outputs.changed == 'true'
       - name: Install helm-unittest
         run: |
           helm plugin uninstall unittest 2>/dev/null || true
@@ -56,7 +55,10 @@ jobs:
       - name: Run unit tests
         run: helm unittest .
         shell: bash
-      - name: Run chart-testing (install)
-        if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --charts .
-        shell: bash
+
+  install-test:
+    needs: lint-test
+    if: needs.lint-test.outputs.changed == 'true'
+    uses: ./.github/workflows/install-test-chart.yaml
+    with:
+      ref: ${{ github.sha }}

--- a/.github/workflows/publish-artifactory-on-merge.yaml
+++ b/.github/workflows/publish-artifactory-on-merge.yaml
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow publishes the Helm chart to Apache JFrog Artifactory on every
+# push to main. Published versions use the form {chart_version}-{short_sha}
+# and are not official releases.
+#
+# Required GitHub Secrets:
+#   ARTIFACTORY_USERNAME -- Apache JFrog Artifactory username
+#   ARTIFACTORY_PASSWORD -- Apache JFrog Artifactory password
+
+name: Publish Helm Chart to Artifactory on Merge
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: publish-artifactory-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    outputs:
+      publish_version: ${{ steps.publish-version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Extract version from Chart.yaml
+        id: versions
+        run: |
+          CHART_VERSION=$(grep '^version:' Chart.yaml | sed 's/version: *"\(.*\)"/\1/')
+          echo "chart_version=$CHART_VERSION" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Set publish version
+        id: publish-version
+        run: |
+          PUBLISH_VERSION="${{ steps.versions.outputs.chart_version }}-${GITHUB_SHA:0:7}"
+          echo "version=$PUBLISH_VERSION" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Override version in Chart.yaml
+        run: |
+          sed -i "s/^version: .*/version: \"${{ steps.publish-version.outputs.version }}\"/" Chart.yaml
+        shell: bash
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install helm-push-artifactory-plugin
+        run: helm plugin install https://github.com/belitre/helm-push-artifactory-plugin --version 1.0.2
+        shell: bash
+
+      - name: Push Helm chart to Artifactory
+        env:
+          HELM_REPO_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          HELM_REPO_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+        run: helm push-artifactory . https://apache.jfrog.io/artifactory/tika
+        shell: bash
+
+  test-published:
+    needs: publish
+    uses: ./.github/workflows/install-test-chart.yaml
+    with:
+      chart_version: ${{ needs.publish.outputs.publish_version }}
+    secrets:
+      ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+      ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/publish-artifactory-on-merge.yaml
+++ b/.github/workflows/publish-artifactory-on-merge.yaml
@@ -78,7 +78,7 @@ jobs:
         shell: bash
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
 
       - name: Set up JFrog CLI
         uses: jfrog/setup-jfrog-cli@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,7 @@ jobs:
           prerelease: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
 
       - name: Set up JFrog CLI
         uses: jfrog/setup-jfrog-cli@v4

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ in which case you may need to augment the commands below.
 
 * Add the Tika Helm charts repo:
 `helm repo add tika https://apache.jfrog.io/artifactory/tika`
+  Charts built from the main branch (version suffix e.g. `-a1b2c3d`) are also published here; they are not official releases.
 
 * Install it:
   - with Helm 3: `helm install tika tika/tika --set image.tag=${release.version} -n tika-test`, you will see something like

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -44,6 +44,7 @@ in which case you may need to augment the commands below.
 
 * Add the Tika Helm charts repo:
 `helm repo add tika https://apache.jfrog.io/artifactory/tika`
+  Charts built from the main branch (version suffix e.g. `-a1b2c3d`) are also published here; they are not official releases.
 
 * Install it:
   - with Helm 3: `helm install tika tika/tika --set image.tag=${release.version} -n tika-test`, you will see something like


### PR DESCRIPTION
PR for [TIKA-4678](https://issues.apache.org/jira/browse/TIKA-4678). This would actually be an excellent way of testing out https://github.com/apache/tika-helm/pull/32 😄 
I decided to extract install and test into a separate dependent workflow which is then called from upstream. Finally, I expanded test coverage for the installed chart.